### PR TITLE
Remove post link from front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
     <div class="panel-body">
       {% assign post = site.posts.first %}
       <header class="post-header">
-        <h1><a href="{{ post.url }}">{{ post.title  }}</a></h1>
+        <h1>{{ post.title  }}</h1>
         <div class="meta">
           {{ site.time | date: "%b %-d, %Y" }}
         </div>


### PR DESCRIPTION
We don't have a "news" page anymore and clicking those links just brought you to a page that
looks identical to the front page sans bubble pics at the bottom.  So it's really not
necessary.