### PR TITLE
Add Sponsor Me Button

### DIFF
--- a/_layouts/greyhound.html
+++ b/_layouts/greyhound.html
@@ -12,6 +12,18 @@ layout: page
     {{ content }}
   </div>
 </div>
+
+{% if greyhound.available %}
+  <div class="text-center">
+    <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+    <input type="hidden" name="cmd" value="_s-xclick">
+    <input type="hidden" name="hosted_button_id" value="GZRB2KX3VM7C4">
+    <input type="hidden" name="item_name" value="Donation to Sponsor {{ greyhound.name }}">
+    <input type="submit" name="submit" value="Sponsor Me!" class="btn btn-lg btn-primary">
+    </form>
+  </div>
+{% endif %}
+
 <p>
 
 <div class="panel-footer">


### PR DESCRIPTION
The Sponsor Me button shows up on available greyhound pages for people to add a donation to a
specific greyhound.  The Sponsor Me button directs people to PayPal with a message "Donation to
Sponsor (Greyhound Name)", where they can enter their donation.

Reviewers: @Catelyn @gpa-treasurer

Available Greyhound with Sponsor Me button
![sponsor_me](https://cloud.githubusercontent.com/assets/2996465/17087927/553a9856-51d9-11e6-8a00-806d9e54480f.png)

PayPal page with Greyhound's name in message
![sponsor_me-1](https://cloud.githubusercontent.com/assets/2996465/17087928/5c38641c-51d9-11e6-91b0-1a6f8b7649b6.png)

Adopted Greyhound without Sponsor Me button
![sponsor_me-2](https://cloud.githubusercontent.com/assets/2996465/17087929/6029595a-51d9-11e6-86b7-fe8797ca7fb6.png)
