### PR TITLE
Calculate a Greyhound's age label based on date of birth

### DIFF
--- a/_data/greyhounds.yml
+++ b/_data/greyhounds.yml
@@ -43,15 +43,6 @@ jay:
   cats: no
   available: yes
 
-simmons:
-  name: Simmons
-  pic: simmons.jpg
-  sex: MALE
-  age: 2 YEARS
-  color: FAWN
-  cats:
-  available: no
-
 breeze:
   name: Breeze
   pic: breeze.JPG
@@ -60,6 +51,42 @@ breeze:
   color: BLACK
   cats: no
   available: yes
+
+lexi:
+  name: Lexi
+  pic: lexi.jpg
+  sex: FEMALE
+  age:  2 YEARS
+  color: FAWN
+  cats:
+  available: yes
+
+jamesbond:
+  name: James Bond
+  pic: jamesbond.jpeg
+  sex: MALE
+  age: 2 YEARS
+  color: BLACK
+  cats: yes
+  available: yes
+
+johaunna:
+  name: Johaunna
+  pic: johaunna.jpg
+  sex: FEMALE
+  age: 3 YEARS
+  color: BLACK
+  cats: no
+  available: yes
+
+simmons:
+  name: Simmons
+  pic: simmons.jpg
+  sex: MALE
+  age: 2 YEARS
+  color: FAWN
+  cats:
+  available: no
 
 georgie:
   name: Georgie
@@ -88,15 +115,6 @@ plante:
   cats: yes
   available: no
 
-jamesbond:
-  name: James Bond
-  pic: jamesbond.jpeg
-  sex: MALE
-  age: 2 YEARS
-  color: BLACK
-  cats: yes
-  available: yes
-
 gregory:
   name: Gregory
   pic: gregory.jpg
@@ -114,15 +132,6 @@ flower:
   color: BLACK
   cats: yes
   available: no
-
-johaunna:
-  name: Johaunna
-  pic: johaunna.jpg
-  sex: FEMALE
-  age: 3 YEARS
-  color: BLACK
-  cats: no
-  available: yes
 
 ballatore:
   name: Ballatore
@@ -321,15 +330,6 @@ hurst:
   color: BLACK
   cats: no
   available: no
-
-lexi:
-  name: Lexi
-  pic: lexi.jpg
-  sex: FEMALE
-  age:  2 YEARS
-  color: FAWN
-  cats:
-  available: yes
 
 noosa:
   name: Noosa
@@ -717,7 +717,8 @@ silversloan:
   sex: FEMALE
   color: BRINDLE
   cats: yes
-  age: Feb 6, 2006 - Nov 18, 2015
+  dob: 2006-02-06
+  dod: 2015-11-18
   available: no
   deceased: yes
 
@@ -767,7 +768,7 @@ robin:
   name: Robin
   pic: robin.jpg
   sex: FEMALE
-  age: April 26, 2016
+  dod: 2016-04-26
   color: BRINDLE
   cats: no
   deceased: yes
@@ -923,7 +924,7 @@ batman:
   name: Batman
   pic: batman.jpg
   sex: MALE
-  age: October 3, 2014
+  dod: 2014-10-03
   color: BLACK & WHITE
   cats: no
   available: no
@@ -1320,7 +1321,8 @@ stormy:
   name: Stormy
   pic: stormy.jpg
   sex: FEMALE
-  age: April 13, 2002 - May 14, 2014
+  dob: 2002-04-13
+  dod: 2014-05-14
   color: DARK BRINDLE
   cats: no
   available: no

--- a/_layouts/greyhound.html
+++ b/_layouts/greyhound.html
@@ -56,8 +56,41 @@ layout: page
         <span class="label label-default">{{ greyhound.color }}</span>
       {% endif %}
 
-      {% if greyhound.age %}
-        <span class="label label-default">{{ greyhound.age }}</span>
+      <!-- Deceased Greyhounds -->
+      {% if greyhound.deceased %}
+        {% if greyhound.dob and greyhound.dod %}
+            {% assign born = greyhound.dob | date_to_string %}
+            {% assign died = greyhound.dod | date_to_string %}
+            <span class="label label-default">{{ born }} - {{ died }}</span>
+        {% elsif greyhound.dod %}
+            <span class="label label-default">Died {{ greyhound.dod | date_to_string }}</span>
+        {% else %}
+            <span class="label label-default">Deceased</span>
+        {% endif %}
+      <!-- Available Greyhounds -->
+      {% elsif greyhound.available %}
+        {% if greyhound.dob %}
+          {% assign years = greyhound.dob | date: '%Y' %}
+          {% assign age = site.time | date: '%Y' | minus: years %}
+          {% if age > 1 %}
+            <span class="label label-default">{{ age }} YEARS</span>
+          {% elsif age != 0 %}
+            <span class="label label-default">{{ age }} YEAR</span>
+          {% else %}
+            {% assign months = greyhound.dob | date: '%m' %}
+            {% assign age = site.time | date: '%m' | minus: months %}
+            <span class="label label-default">{{ age }} MONTHS</span>
+          {% endif %}
+        {% elsif greyhound.age %}
+            <span class="label label-default">{{ greyhound.age }}</span>
+        {% endif %}
+      <!-- Adopted Greyhounds -->
+      {% else %}
+        {% if greyhound.dob %}
+          <span class="label label-default">Born {{ greyhound.dob | date_to_string }}</span>
+        {% elsif greyhound.age %}
+            <span class="label label-default">{{ greyhound.age }}</span>
+        {% endif %}
       {% endif %}
 
     </div>

--- a/script/spellcheck.rb
+++ b/script/spellcheck.rb
@@ -26,7 +26,7 @@ module Spellcheck
     def spellcheck
       rval = 0
       md = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
-      files = `git ls-files`.split.select { |v| v =~ /(\.html|\.md)/ }
+      files = `git ls-files`.split.select { |file| file =~ /(\.html|\.md)/ and file !~ /^(_layouts|_includes)/ }
       files.each do |file|
         tmpfile = "#{file}.tmp"
         File.write(tmpfile, md.render(File.read(file)))


### PR DESCRIPTION
Each greyhound in _data/greyhounds.yml can be given a date of birth field (dob) with a date formatted like so: YYYY-MM-DD
which will be used to create the age label for their profile page.
The greyhound's age will then automatically be updated when the site is rebuilt.

For available greyhounds, the age label will be how many years or months old a greyhound is.
e.g. "5 YEARS" or "8 MONTHS"

For adopted greyhounds, the age label will be the greyhound's birthday.
e.g. "Born 01 Jan 2000"

For deceased greyhounds, a date of death field (dod) will also be used to set the age label to a duration of life, or the greyhound's deathday
e.g. "01 Jan 2000 - 01 Jan 2010" or "Died 01 Jan 2010"